### PR TITLE
include LICENSE file in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.15.0"
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "bindings/rust/*",
   "grammar.js",
   "queries/*",


### PR DESCRIPTION
Summary:
Because of the `include=` directive, we need to explicitly include the license file as well or it won't end up in the generated crate.

Needed to package this in Fedora as a dependency of `difftastic`.

```
$ cargo package --allow-dirty --list | grep LICENSE
LICENSE
```

Differential Revision: D89675738


